### PR TITLE
fix: add React.memo to reduce re-renders

### DIFF
--- a/components/EmojiThrow.tsx
+++ b/components/EmojiThrow.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useMemo } from 'react';
+import React, { useRef, useMemo, memo } from 'react';
 import { Html } from '@react-three/drei';
 import { useFrame } from '@react-three/fiber';
 import * as THREE from 'three';
@@ -14,8 +14,11 @@ interface EmojiThrowProps {
 /**
  * Component that animates an emoji flying from one player position to another.
  * Uses quadratic bezier curve for a natural arc trajectory.
+ *
+ * Memoized to prevent re-renders when new emoji throws are added to the array.
+ * Each throw has unique ID - existing throws shouldn't re-render when new ones appear.
  */
-export const EmojiThrow: React.FC<EmojiThrowProps> = ({
+export const EmojiThrow: React.FC<EmojiThrowProps> = memo(({
   throw: throwData,
   fromPosition,
   toPosition,
@@ -89,4 +92,9 @@ export const EmojiThrow: React.FC<EmojiThrowProps> = ({
       </Html>
     </group>
   );
-};
+}, (prevProps, nextProps) => {
+  // Only check ID - throws are "fire-and-forget" animations
+  // Once mounted, trajectory and callback are captured and shouldn't change
+  // This prevents re-renders when new throws are added to the parent array
+  return prevProps.throw.id === nextProps.throw.id;
+});


### PR DESCRIPTION
## Summary
Add `React.memo` with custom comparison functions to expensive components to prevent unnecessary re-renders.

## Problem
- Every WebSocket message triggered full state update
- All 9 PlayerSeat components re-rendered on every emoji throw
- All EmojiThrow components re-rendered when new throws added

## Solution

### PlayerSeat - Custom comparison
```tsx
memo(PlayerSeat, (prev, next) => {
  return (
    prev.player.id === next.player.id &&
    prev.player.vote === next.player.vote &&
    prev.player.health === next.player.health &&
    // ... other player-specific props
  );
});
```

### EmojiThrow - ID-based comparison
```tsx
memo(EmojiThrow, (prev, next) => {
  return prev.throw.id === next.throw.id;
});
```

## Impact
- PlayerSeat only re-renders when **that specific player's** state changes
- EmojiThrow doesn't re-render when new throws are added to the array
- Significantly reduced React reconciliation work during rapid emoji throwing

## Related Issue
Closes #5
Part of coordinator issue #1

## Test Plan
- [ ] Open React DevTools Profiler
- [ ] Throw emojis rapidly between players
- [ ] Verify only affected PlayerSeats re-render (not all 9)
- [ ] Verify existing EmojiThrows don't re-render when new ones added